### PR TITLE
count($body->comments) causes "Argument must be of type Countable|array, stdClass given"

### DIFF
--- a/src/DoStats/GitLogStats.php
+++ b/src/DoStats/GitLogStats.php
@@ -353,7 +353,7 @@ class GitLogStats
                 'Title' => $this->truncate($body->title, 100),
                 'ID' => $body->nid,
                 'Category' => 'Other',
-                'Size' => $this->mapSizeFromCommentCount(count($body->comments)),
+                'Size' => $this->mapSizeFromComments($body->comments),
                 'Project' => 'unknown',
             ];
         }
@@ -362,7 +362,7 @@ class GitLogStats
             'Title' => $this->truncate($body->title, 100),
             'ID' => $body->nid,
             'Category' => $this->mapCategory($body->field_issue_category),
-            'Size' => $this->mapSizeFromCommentCount(count($body->comments)),
+            'Size' => $this->mapSizeFromComments($body->comments),
             'Project' => $body->field_project->machine_name,
             'Contributors' => implode(', ', $truncatedContributors),
         ];
@@ -590,14 +590,15 @@ class GitLogStats
      * Attempts to determine the "size" (effort/points) of an issue based on the
      * number of comments it has.
      *
-     * @param int $count
-     *   The numbed of comments on an issue.
+     * @param object $comments
+     *   The comments on an issue.
      *
      * @return int
      *   The mapped "size".
      */
-    protected function mapSizeFromCommentCount($count)
+    protected function mapSizeFromComments($comments)
     {
+        $count = count((array) $comments);
         switch ($count) {
             case ($count > 100):
                 $size = 21;


### PR DESCRIPTION
$body->comments is a stdClass. Before PHP 7.2, counting an object always returns 1 (defeating the point of this code anyway).
But in 7.2-7.4, it emits a warning, and after 8.0 it is a fatal error.

Casting to an array first fixes it. I moved the cast into the helper method.